### PR TITLE
Generate Silent Payment Address

### DIFF
--- a/class/wallets/abstract-wallet.ts
+++ b/class/wallets/abstract-wallet.ts
@@ -159,6 +159,14 @@ export class AbstractWallet {
     return false;
   }
 
+  allowSilentPaymentReceive(): boolean {
+    return false;
+  }
+
+  getSilentPaymentAddress(): string | null {
+    return null;
+  }
+
   allowRBF(): boolean {
     return false;
   }
@@ -415,6 +423,10 @@ export class AbstractWallet {
   }
 
   isBIP47Enabled(): boolean {
+    return false;
+  }
+
+  isBIP352Enabled(): boolean {
     return false;
   }
 

--- a/loc/en.json
+++ b/loc/en.json
@@ -688,5 +688,10 @@
     "notif_tx_sent" : "Notification transaction sent. Please wait for it to confirm",
     "notif_tx": "Notification transaction",
     "not_found": "Payment code not found"
+  },
+  "bip352": {
+    "silent_payments": "Silent Payments",
+    "not_supported": "Silent Payments not supported by this wallet",
+    "explanation": "Silent Payment addresses are reusable, allowing you to share a single address for multiple payments without compromising privacy."
   }
 }

--- a/tests/unit/bip352.test.ts
+++ b/tests/unit/bip352.test.ts
@@ -1,0 +1,20 @@
+import { HDSegwitBech32Wallet } from '../../class';
+
+describe('BIP-352 Silent Payments', () => {
+  it('should generate a valid silent payment address', () => {
+    const wallet1 = new HDSegwitBech32Wallet();
+    const wallet2 = new HDSegwitBech32Wallet();
+    wallet1.setSecret('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+    wallet2.setSecret('zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo glue');
+
+    const silentPaymentAddress1 = wallet1.getSilentPaymentAddress();
+    const silentPaymentAddress2 = wallet2.getSilentPaymentAddress();
+
+    expect(silentPaymentAddress1).toBe(
+      'sp1qqfqnnv8czppwysafq3uwgwvsc638hc8rx3hscuddh0xa2yd746s7xqh6yy9ncjnqhqxazct0fzh98w7lpkm5fvlepqec2yy0sxlq4j6ccc3h6t0g',
+    );
+    expect(silentPaymentAddress2).toBe(
+      'sp1qqvchcnrcqpdutxhpf57ptn3wajj0ymqxwzu9g6vj9uxx3wuvlykhyqh99hyh33y5593802pzw5rtw040zrw9f8re52tgcwngc5974w5evuufdy0m',
+    );
+  });
+});


### PR DESCRIPTION
this is a basic implementation for generating a Silent Payment address, which becomes available only when the user enables the 'Reusable and shareable address' option.

i have tested this implementation against the same mnemonic with [silentium](https://app.silentium.dev/)