### PR TITLE
[FIX] Real-time wallet balance updates and scan progress persistence

### DIFF
--- a/class/wallets/hd-bip352-wallet.ts
+++ b/class/wallets/hd-bip352-wallet.ts
@@ -40,9 +40,14 @@ export class HDSilentPaymentsWallet extends HDSegwitBech32Wallet {
   private pollingIntervalId: NodeJS.Timeout | null = null;
   private isPollingActive: boolean = false;
   private onBalanceChangeCallback: (() => void) | null = null;
+  private onPersistCallback: (() => void) | null = null;
 
   setOnBalanceChangeCallback(callback: (() => void) | null): void {
     this.onBalanceChangeCallback = callback;
+  }
+
+  setOnPersistCallback(callback: (() => void) | null): void {
+    this.onPersistCallback = callback;
   }
 
   static fromJson(obj: string): HDSilentPaymentsWallet {
@@ -124,6 +129,10 @@ export class HDSilentPaymentsWallet extends HDSegwitBech32Wallet {
         this.onBalanceChangeCallback();
       }
       
+      if (this.onPersistCallback) {
+        this.onPersistCallback();
+      }
+      
       return true;
     }
     
@@ -199,12 +208,21 @@ export class HDSilentPaymentsWallet extends HDSegwitBech32Wallet {
       }
     }
     
+    // Always update lastScannedBlock to track progress, even if no UTXOs found
     if (newLastScannedBlock > this.lastScannedBlock) {
       this.lastScannedBlock = newLastScannedBlock;
     }
     
-    if (addedCount > 0 && this.onBalanceChangeCallback) {
-      this.onBalanceChangeCallback();
+    // Trigger callbacks if state changed
+    if (addedCount > 0) {
+      if (this.onBalanceChangeCallback) {
+        this.onBalanceChangeCallback();
+      }
+    }
+    
+    // Always persist when lastScannedBlock updates to track scan progress
+    if (newLastScannedBlock > 0 && this.onPersistCallback) {
+      this.onPersistCallback();
     }
     
     return addedCount;
@@ -583,5 +601,7 @@ export class HDSilentPaymentsWallet extends HDSegwitBech32Wallet {
     
     this.stopPolling();
     this.invalidateUTXOCache();
+    this.onBalanceChangeCallback = null;
+    this.onPersistCallback = null;
   }
 }

--- a/components/Context/StorageProvider.tsx
+++ b/components/Context/StorageProvider.tsx
@@ -170,14 +170,30 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
     setWallets([...BlueApp.getWallets()]);
   }, []);
 
+  // Debounced persist to avoid excessive saves during rapid scans
+  const persistTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const debouncedPersist = useCallback(() => {
+    if (persistTimeoutRef.current) clearTimeout(persistTimeoutRef.current);
+    persistTimeoutRef.current = setTimeout(() => saveToDisk(), 2000);
+  }, [saveToDisk]);
+
+  useEffect(() => {
+    return () => {
+      if (persistTimeoutRef.current) clearTimeout(persistTimeoutRef.current);
+    };
+  }, []);
+
   const addWallet = useCallback((wallet: TWallet) => {
     if ('setOnBalanceChangeCallback' in wallet && typeof wallet.setOnBalanceChangeCallback === 'function') {
       wallet.setOnBalanceChangeCallback(forceWalletsUpdate);
     }
+    if ('setOnPersistCallback' in wallet && typeof wallet.setOnPersistCallback === 'function') {
+      wallet.setOnPersistCallback(debouncedPersist);
+    }
     
     BlueApp.wallets.push(wallet);
     setWallets([...BlueApp.getWallets()]);
-  }, [forceWalletsUpdate]);
+  }, [forceWalletsUpdate, debouncedPersist]);
 
   const deleteWallet = useCallback((wallet: TWallet) => {
     if ('clearCache' in wallet && typeof wallet.clearCache === 'function')
@@ -324,11 +340,14 @@ export const StorageProvider = ({ children }: { children: React.ReactNode }) => 
         if ('setOnBalanceChangeCallback' in wallet && typeof wallet.setOnBalanceChangeCallback === 'function') {
           wallet.setOnBalanceChangeCallback(forceWalletsUpdate);
         }
+        if ('setOnPersistCallback' in wallet && typeof wallet.setOnPersistCallback === 'function') {
+          wallet.setOnPersistCallback(debouncedPersist);
+        }
       });
       
       setWallets(currentWallets);
     }
-  }, [walletsInitialized, forceWalletsUpdate]);
+  }, [walletsInitialized, forceWalletsUpdate, debouncedPersist]);
 
   // Add a refresh lock to prevent concurrent refreshes
   const refreshingRef = useRef<boolean>(false);


### PR DESCRIPTION
### Problem
Silent Payment wallet balance wasn't updating on the home screen until user interaction (button press).
wallet state wasn't persisting to disk, causing full rescans on every app restart
Scan progress was lost if app was closed during scanning

## Solution
**Implemented callback mechanism with debounced persistence:**


https://github.com/user-attachments/assets/d76c6d67-4e88-4dab-aa5d-9817a02f8fda


