### PR TITLE
ci: disable ci

### DIFF
--- a/.github/workflows/build-ios-release-pullrequest.yml
+++ b/.github/workflows/build-ios-release-pullrequest.yml
@@ -1,13 +1,6 @@
 name: Build Release and Upload to TestFlight (iOS)
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, reopened, synchronize, labeled]
-    branches:
-      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,13 +1,7 @@
 name: BuildReleaseApk
 
 on:
-  pull_request:
-    branches:
-      - master
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   buildReleaseApk:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ env:
   HD_MNEMONIC: ${{ secrets.HD_MNEMONIC }}
   HD_MNEMONIC_BIP84: ${{ secrets.HD_MNEMONIC_BIP84 }}
 
-on: [pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/lockfiles_update.yml
+++ b/.github/workflows/lockfiles_update.yml
@@ -2,9 +2,6 @@ name: Lock Files Update
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
 
 jobs:
   pod-update:


### PR DESCRIPTION
disable all CI pipelines so that it can only be run manually. CI pipeline runs cost money and are proably billed to Bitshala-Incubator organisation