### PR TITLE
FIX: remove the uppercase conversion logic from DeeplinkSchemaMatch

### DIFF
--- a/class/deeplink-schema-match.ts
+++ b/class/deeplink-schema-match.ts
@@ -412,12 +412,6 @@ class DeeplinkSchemaMatch {
   }
 
   static bip21encode(address: string, options?: TOptions): string {
-    // uppercase address if bech32 to satisfy BIP_0173
-    const isBech32 = address.startsWith('bc1');
-    if (isBech32) {
-      address = address.toUpperCase();
-    }
-
     for (const key in options) {
       if (key === 'label' && String(options[key]).replace(' ', '').length === 0) {
         delete options[key];


### PR DESCRIPTION
Fixes #61 : Bech32 addresses scanned from the QR codes on Receive Screen are in Uppercase

This PR removes the uppercase conversion logic from DeeplinkSchemaMatch.bip21encode() 
Addresses now maintain their original lowercase format

Testing: 
- [x] QR codes scan correctly with lowercase addresses
- [x] Addresses generated through display checked on mempool.space for validity
- [x] Verified all existing tests pass