### PR TITLE
Fix build-release-apk workflow

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - master
@@ -15,26 +14,26 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: "0"
 
       - name: Specify node version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Use specific Java version for sdkmanager to work
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
       - name: Install node_modules
-        run: npm ci --omit=dev --yes
+        run: npm ci --omit=dev
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -46,9 +45,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-ruby-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gems-
+            ${{ runner.os }}-ruby-
 
       - name: Generate Build Number based on timestamp
         id: build_number
@@ -60,6 +59,14 @@ jobs:
         run: bundle exec fastlane android prepare_keystore
         env:
           KEYSTORE_FILE_HEX: ${{ secrets.KEYSTORE_FILE_HEX }}
+
+      - name: Verify Keystore
+        run: |
+          echo "Keystore file size: $(wc -c < shroud-release-key.keystore) bytes"
+          echo "Keystore file header: $(xxd -l 4 shroud-release-key.keystore)"
+          keytool -list -keystore shroud-release-key.keystore -storepass "$KEYSTORE_PASSWORD" || echo "Keystore verification failed"
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
       - name: Update Version Code, Build, and Sign APK
         id: build_and_sign_apk
@@ -77,9 +84,9 @@ jobs:
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9_-]/_/g')
 
           if [ -n "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "master" ]; then
-            EXPECTED_FILENAME="BlueWallet-${VERSION_NAME}-${NEW_BUILD_NUMBER}-${BRANCH_NAME}.apk"
+            EXPECTED_FILENAME="Shroud-${VERSION_NAME}-${NEW_BUILD_NUMBER}-${BRANCH_NAME}.apk"
           else
-            EXPECTED_FILENAME="BlueWallet-${VERSION_NAME}-${NEW_BUILD_NUMBER}.apk"
+            EXPECTED_FILENAME="Shroud-${VERSION_NAME}-${NEW_BUILD_NUMBER}.apk"
           fi
       
           APK_PATH="android/app/build/outputs/apk/release/${EXPECTED_FILENAME}"
@@ -87,44 +94,9 @@ jobs:
           echo "APK_PATH=${APK_PATH}" >> $GITHUB_ENV
 
       - name: Upload APK as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: signed-apk
           path: ${{ env.APK_PATH }}
           if-no-files-found: error
 
-  browserstack:
-    runs-on: ubuntu-latest
-    needs: buildReleaseApk
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'browserstack') }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1.6
-          bundler-cache: true
-
-      - name: Install dependencies with Bundler
-        run: bundle install --jobs 4 --retry 3
-
-      - name: Download APK artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: signed-apk
-
-      - name: Set APK Path
-        run: |
-          APK_PATH=$(find ${{ github.workspace }} -name '*.apk')
-          echo "APK_PATH=$APK_PATH" >> $GITHUB_ENV
-
-      - name: Upload APK to BrowserStack and Post PR Comment
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bundle exec fastlane upload_to_browserstack_and_comment

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         path: node_modules
         key: node-modules-${{ hashFiles('package-lock.json') }}
+
     - name: Install Dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci

--- a/.github/workflows/lockfiles_update.yml
+++ b/.github/workflows/lockfiles_update.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Checkout master branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: master  # Ensures we're checking out the master branch
           fetch-depth: 0 # Ensures full history to enable branch deletion and recreation
@@ -28,9 +28,9 @@ jobs:
         run: git checkout -b pod-update-branch  # Create a new branch from the master branch
 
       - name: Specify node version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,6 +25,7 @@ jobs:
       with:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
+
     - name: Install Dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,7 +82,7 @@ def cached_app_store_connect_login
 end
 
 before_all do |lane, options|
-  skip_auth_lanes = ['register_devices_from_txt']
+  skip_auth_lanes = [:register_devices_from_txt, :prepare_keystore, :update_version_build_and_sign_apk]
   
   # Check if we need App Store Connect for this lane
   unless skip_auth_lanes.include?(lane)
@@ -110,14 +110,14 @@ platform :android do
       UI.user_error!("KEYSTORE_FILE_HEX environment variable is missing") if keystore_file_hex.nil?
 
       UI.message("Creating keystore from HEX...")
-      File.write("bluewallet-release-key.keystore.hex", keystore_file_hex)
+      File.write("shroud-release-key.keystore.hex", keystore_file_hex)
 
-      sh("xxd -plain -revert bluewallet-release-key.keystore.hex > bluewallet-release-key.keystore") do |status|
+      sh("xxd -plain -revert shroud-release-key.keystore.hex > shroud-release-key.keystore") do |status|
         UI.user_error!("Error reverting hex to keystore") unless status.success?
       end
       UI.message("Keystore created successfully.")
 
-      File.delete("bluewallet-release-key.keystore.hex")
+      File.delete("shroud-release-key.keystore.hex")
     end
   end
 
@@ -145,8 +145,8 @@ platform :android do
  
       # Define APK name based on branch
       signed_apk_name = branch_name != 'master' ? 
-        "BlueWallet-#{version_name}-#{build_number}-#{branch_name}.apk" : 
-        "BlueWallet-#{version_name}-#{build_number}.apk"
+        "Shroud-#{version_name}-#{build_number}-#{branch_name}.apk" :
+        "Shroud-#{version_name}-#{build_number}.apk"
  
       # Define paths
       unsigned_apk_path = "android/app/build/outputs/apk/release/app-release-unsigned.apk"
@@ -171,7 +171,7 @@ platform :android do
       UI.message("Signing APK with apksigner...")
       apksigner_path = Dir.glob("#{ENV['ANDROID_HOME']}/build-tools/*/apksigner").sort.last
       UI.user_error!("apksigner not found in Android build-tools") if apksigner_path.nil? || apksigner_path.empty?
-      sh("#{apksigner_path} sign --ks #{project_root}/bluewallet-release-key.keystore --ks-pass=pass:#{ENV['KEYSTORE_PASSWORD']} #{signed_apk_path}")
+      sh("#{apksigner_path} sign --ks #{project_root}/shroud-release-key.keystore --ks-pass env:KEYSTORE_PASSWORD #{signed_apk_path}")
       UI.message("APK signed successfully: #{signed_apk_path}")
     end
   end

--- a/package-lock.json
+++ b/package-lock.json
@@ -10121,6 +10121,20 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",


### PR DESCRIPTION
This PR
- renames BlueWallet references to Shroud for android build
- removes browerstack job (paid service, requires subscription)
- bumps up node to v24 across jobs