### PR TITLE
OPS: update integration tests and self-test with addresses and balances

### DIFF
--- a/screen/settings/SelfTest.tsx
+++ b/screen/settings/SelfTest.tsx
@@ -279,9 +279,9 @@ export default class SelfTest extends Component {
         //
 
         const hd4 = new HDSegwitBech32Wallet();
-        hd4._xpub = 'zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP';
+        hd4._xpub = 'zpub6rnbAtzupLPpSrsBKRsHupFvv1h6pwfRnZxX3qs6RL4LiLqKQ6kfBaDckn2apQWfyw1D2TdQMMDCfUDHMwtrcbGoy88xoKBLmADTFK9AhLe';
         await hd4.fetchBalance();
-        if (hd4.getBalance() !== 200000) throw new Error('Could not fetch HD Bech32 balance');
+        if (hd4.getBalance() !== 2400) throw new Error('Could not fetch HD Bech32 balance');
         await hd4.fetchTransactions();
         if (hd4.getTransactions().length !== 4) throw new Error('Could not fetch HD Bech32 transactions');
       } else {

--- a/tests/integration/BlueElectrum.test.js
+++ b/tests/integration/BlueElectrum.test.js
@@ -132,10 +132,10 @@ describe('BlueElectrum', () => {
   });
 
   it('BlueElectrum can do getTransactionsByAddress()', async function () {
-    const txs = await BlueElectrum.getTransactionsByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    const txs = await BlueElectrum.getTransactionsByAddress('bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc');
     assert.strictEqual(txs.length, 1);
-    assert.strictEqual(txs[0].tx_hash, 'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d');
-    assert.strictEqual(txs[0].height, 563077);
+    assert.strictEqual(txs[0].tx_hash, '84b1a1b44726e5120533037edb8406ef46fa84c2f8dd50ada4ba72fa05af1dae');
+    assert.strictEqual(txs[0].height, 933626);
   });
 
   // skipped because requires fresh address with pending txs every time
@@ -152,21 +152,20 @@ describe('BlueElectrum', () => {
 
   it('BlueElectrum can do getTransactionsFullByAddress()', async function () {
     const txs = await BlueElectrum.getTransactionsFullByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-    for (const tx of txs) {
-      assert.ok(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
-      assert.ok(tx.txid);
-      assert.ok(tx.confirmations);
-      assert.ok(!tx.vin);
-      assert.ok(!tx.vout);
-      assert.ok(tx.inputs);
-      assert.strictEqual(tx.inputs[0]?.addresses[0], 'bc1q7td49wcxfad9v42kmvg5refn9wcnvnru4395qw');
-      assert.ok(tx.inputs[0].addresses.length > 0);
-      assert.ok(tx.inputs[0].value > 0);
-      assert.ok(tx.outputs);
-      assert.ok(tx.outputs[0].value > 0);
-      assert.ok(tx.outputs[0].scriptPubKey);
-      assert.ok(tx.outputs[0].addresses.length > 0);
-    }
+    const tx = txs[0];
+    assert.ok(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    assert.ok(tx.txid);
+    assert.ok(tx.confirmations);
+    assert.ok(!tx.vin);
+    assert.ok(!tx.vout);
+    assert.ok(tx.inputs);
+    assert.strictEqual(tx.inputs[0]?.addresses[0], 'bc1q7td49wcxfad9v42kmvg5refn9wcnvnru4395qw');
+    assert.ok(tx.inputs[0].addresses.length > 0);
+    assert.ok(tx.inputs[0].value > 0);
+    assert.ok(tx.outputs);
+    assert.ok(tx.outputs[0].value > 0);
+    assert.ok(tx.outputs[0].scriptPubKey);
+    assert.ok(tx.outputs[0].addresses.length > 0);
   });
 
   it('BlueElectrum can do txhexToElectrumTransaction()', () => {
@@ -179,23 +178,23 @@ describe('BlueElectrum', () => {
   it.each([false, true])('BlueElectrum can do multiGetBalanceByAddress(), disableBatching=%p', async function (diableBatching) {
     if (diableBatching) BlueElectrum.setBatchingDisabled();
     const balances = await BlueElectrum.multiGetBalanceByAddress([
-      'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh',
-      'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p',
-      'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r',
+      'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc',
+      'bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8',
+      'bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp',
       '3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK',
-      'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy',
+      'bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj',
     ]);
 
-    assert.strictEqual(balances.balance, 200000 + 51432);
+    assert.strictEqual(balances.balance, 2400 + 51432);
     assert.strictEqual(balances.unconfirmed_balance, 0);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r.unconfirmed, 0);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.confirmed, 50000);
-    assert.strictEqual(balances.addresses.bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp.unconfirmed, 0);
+    assert.strictEqual(balances.addresses.bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj.confirmed, 600);
+    assert.strictEqual(balances.addresses.bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj.unconfirmed, 0);
     assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].confirmed, 51432);
     assert.strictEqual(balances.addresses['3GCvDBAktgQQtsbN6x5DYiQCMmgZ9Yk8BK'].unconfirmed, 0);
     if (diableBatching) BlueElectrum.setBatchingEnabled();
@@ -204,22 +203,22 @@ describe('BlueElectrum', () => {
   it('BlueElectrum can do multiGetUtxoByAddress()', async () => {
     const utxos = await BlueElectrum.multiGetUtxoByAddress(
       [
-        'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh',
-        'bc1qvd6w54sydc08z3802svkxr7297ez7cusd6266p',
-        'bc1qwp58x4c9e5cplsnw5096qzdkae036ug7a34x3r',
-        'bc1qcg6e26vtzja0h8up5w2m7utex0fsu4v0e0e7uy',
+        'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc',
+        'bc1qdsf8p4knu2u0h9cspflh0ftjp8qayve3r5nme8',
+        'bc1qzfmm8d9saalnjjnskj2mekycg73hecpajt8urp',
+        'bc1qz28yun0lkkk2fk5ed2gdpnfra8970umtsd58gj',
       ],
       3,
     );
 
     assert.strictEqual(Object.keys(utxos).length, 4);
     assert.strictEqual(
-      utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].txid,
-      'ad00a92409d8982a1d7f877056dbed0c4337d2ebab70b30463e2802279fb936d',
+      utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].txid,
+      '84b1a1b44726e5120533037edb8406ef46fa84c2f8dd50ada4ba72fa05af1dae',
     );
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].vout, 1);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].value, 50000);
-    assert.strictEqual(utxos.bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh[0].address, 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].vout, 0);
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].value, 600);
+    assert.strictEqual(utxos.bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc[0].address, 'bc1qe7q08prc2spln2l7qdvvlcgqxm9za9z7mjnpzc');
   });
 
   it.each([false, true])('ElectrumClient can do multiGetHistoryByAddress(), disableBatching=%p', async disableBatching => {

--- a/tests/integration/BlueElectrum.test.js
+++ b/tests/integration/BlueElectrum.test.js
@@ -152,6 +152,7 @@ describe('BlueElectrum', () => {
 
   it('BlueElectrum can do getTransactionsFullByAddress()', async function () {
     const txs = await BlueElectrum.getTransactionsFullByAddress('bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
+    assert.ok(txs.length >= 1);
     const tx = txs[0];
     assert.ok(tx.address === 'bc1qt4t9xl2gmjvxgmp5gev6m8e6s9c85979ta7jeh');
     assert.ok(tx.txid);

--- a/tests/integration/watch-only-wallet.test.js
+++ b/tests/integration/watch-only-wallet.test.js
@@ -85,19 +85,19 @@ describe('Watch only wallet', () => {
 
   it('can fetch balance & transactions from zpub HD', async () => {
     const w = new WatchOnlyWallet();
-    w.setSecret('zpub6r7jhKKm7BAVx3b3nSnuadY1WnshZYkhK8gKFoRLwK9rF3Mzv28BrGcCGA3ugGtawi1WLb2vyjQAX9ZTDGU5gNk2bLdTc3iEXr6tzR1ipNP');
+    w.setSecret('zpub6rnbAtzupLPpSrsBKRsHupFvv1h6pwfRnZxX3qs6RL4LiLqKQ6kfBaDckn2apQWfyw1D2TdQMMDCfUDHMwtrcbGoy88xoKBLmADTFK9AhLe');
     await w.fetchBalance();
-    assert.strictEqual(w.getBalance(), 200000);
+    assert.strictEqual(w.getBalance(), 2400);
     await w.fetchTransactions();
     assert.strictEqual(w.getTransactions().length, 4);
     const nextAddress = await w.getAddressAsync();
 
     assert.strictEqual(w.getNextFreeAddressIndex(), 2);
-    assert.strictEqual(nextAddress, 'bc1q6442dedpwvqldldnsyux3cuz27paqks0pf2kvf');
+    assert.strictEqual(nextAddress, 'bc1q9v6mvgpehtmh0qc3y24mq6auwt8my4l68k9xyj');
     assert.strictEqual(nextAddress, w._getExternalAddressByIndex(w.getNextFreeAddressIndex()));
 
     const nextChangeAddress = await w.getChangeAddressAsync();
-    assert.strictEqual(nextChangeAddress, 'bc1qgltdyjnertcyvdn9hlkfpgr6hc260rjrss49uy');
+    assert.strictEqual(nextChangeAddress, 'bc1q74tz7eflqc62v8utqlazcs3tqtwmvvzud5dmrz');
   });
 
   // skipped because its generally rare case


### PR DESCRIPTION
This PR: 
- Updates `HD Bech32` test wallet `xpub` and `derived addresses` in `tests/integration/watch-only-wallet.test.js`, `tests/integration/BlueElectrum.test.js` and `screen/settings/SelfTest.tsx`
- Updates expected balances across tests
- Updates the expected `txid` and `block height` across tests

Inspired from [#8260](https://github.com/BlueWallet/BlueWallet/pull/8260/) at [Bluewallet](https://github.com/BlueWallet/BlueWallet)