### PR TITLE
FIX: persist birth height to disk

### DIFF
--- a/screen/wallets/OnboardingScreen.tsx
+++ b/screen/wallets/OnboardingScreen.tsx
@@ -41,7 +41,7 @@ const OnboardingScreen: React.FC = () => {
       console.log(`Wallet birth height set to: ${latestHeightResponse.height}`);
       await saveToDisk();
     } catch (error) {
-      console.warn('Could not set birth height, will default to activation height:', error);
+      console.warn('Could not set or persist birth height, will default to activation height:', error);
     }
 
     triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);

--- a/screen/wallets/OnboardingScreen.tsx
+++ b/screen/wallets/OnboardingScreen.tsx
@@ -39,8 +39,9 @@ const OnboardingScreen: React.FC = () => {
       const latestHeightResponse = await indexer.getLatestBlockHeight();
       w.setBirthHeight(latestHeightResponse.height);
       console.log(`Wallet birth height set to: ${latestHeightResponse.height}`);
+      await saveToDisk();
     } catch (error) {
-      console.warn('Could not set birth height, will default to 0:', error);
+      console.warn('Could not set birth height, will default to activation height:', error);
     }
 
     triggerHapticFeedback(HapticFeedbackTypes.NotificationSuccess);


### PR DESCRIPTION
Bug: 

- Wallet birth height not persisted to disk during `Onboarding`
- On restart, wallet loads with default birth height

This PR:
- adds `saveToDisk()` after `setBirthHeight()` to persist the birth height