### PR TITLE
Fix BuildReleaseApk workflow

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -68,6 +68,12 @@ jobs:
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust native libs
+        run: bash rust-native-setup.sh
+
       - name: Update Version Code, Build, and Sign APK
         id: build_and_sign_apk
         run: |

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'gradle'
 
       - name: Install node_modules
-        run: npm ci --omit=dev
+        run: npm ci
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,6 +1,7 @@
 name: BuildReleaseApk
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master
@@ -94,7 +95,7 @@ jobs:
           else
             EXPECTED_FILENAME="Shroud-${VERSION_NAME}-${NEW_BUILD_NUMBER}.apk"
           fi
-      
+
           APK_PATH="android/app/build/outputs/apk/release/${EXPECTED_FILENAME}"
           echo "EXPECTED_FILENAME=${EXPECTED_FILENAME}" >> $GITHUB_ENV
           echo "APK_PATH=${APK_PATH}" >> $GITHUB_ENV

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -72,6 +72,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust_jsi_bridge/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust_jsi_bridge/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Build Rust native libs
         run: bash rust-native-setup.sh
 

--- a/shim.js
+++ b/shim.js
@@ -25,7 +25,6 @@ process.nextTick = function (callback, ...args) {
 
 // global.location = global.location || { port: 80 }
 const isDev = typeof __DEV__ === 'boolean' && __DEV__;
-process.env.NODE_ENV = isDev ? 'development' : 'production';
 if (typeof localStorage !== 'undefined') {
   localStorage.debug = isDev ? '*' : '';
 }


### PR DESCRIPTION
The `BuildReleaseApk` CI workflow has been failing on all PRs on account of :
- Android build-tools 35.0.0 were not guaranteed to be present on the runner, causing APK signing to fail
- The Rust native library was never compiled before the Gradle build, causing a missing `.a` file error
  
This PR : 
- installs `build-tools;35.0.0` via `sdkmanager` before the build step
- adds Rust toolchain setup and compiles the native libs using the existing `rust-native-setup.sh` before Gradle runs
