### PR TITLE
fix(ios): drop orphaned push-notification and quick-actions native refs

### DIFF
--- a/ios/Shroud-Bridging-Header.h
+++ b/ios/Shroud-Bridging-Header.h
@@ -6,5 +6,3 @@
 //  Copyright © 2026 Shroud contributors. All rights reserved.
 //
 
-#import <RNCPushNotificationIOS.h>
-#import "RNQuickActionManager.h"

--- a/ios/Shroud/AppDelegate.swift
+++ b/ios/Shroud/AppDelegate.swift
@@ -328,10 +328,6 @@ class AppDelegate: RCTAppDelegate, UNUserNotificationCenterDelegate {
         UserDefaults.standard.removeObserver(self, forKeyPath: "deviceUID")
     }
 
-    override func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        RNQuickActionManager.onQuickActionPress(shortcutItem, completionHandler: completionHandler)
-    }
-
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.sound, .list, .banner, .badge])
     }
@@ -352,7 +348,6 @@ class AppDelegate: RCTAppDelegate, UNUserNotificationCenterDelegate {
             }
         }
 
-        RNCPushNotificationIOS.didReceive(response)
         completionHandler()
     }
     


### PR DESCRIPTION
## Summary

The iOS build currently fails on master at the bridging header:

```
Shroud-Bridging-Header.h:9:9: fatal error: 'RNCPushNotificationIOS.h' file not found
```

72a8d66f2 (push-notifications removal) and 2a9940c62 (quick-actions removal) dropped the deps and Podfile entries but missed the native iOS references. The break surfaces for anyone who runs `pod install` against the updated Podfile.lock, since the headers those imports pointed at no longer exist in Pods.

## Changes

- **`ios/Shroud-Bridging-Header.h`** — remove both orphaned imports (`RNCPushNotificationIOS.h`, `RNQuickActionManager.h`)
- **`ios/Shroud/AppDelegate.swift`** — remove the `performActionFor shortcutItem` override (its only body was the dead `RNQuickActionManager` call) and the `RNCPushNotificationIOS.didReceive(response)` forwarding call. The local-notification deep-link handling (block-explorer actions) is pure Apple `UserNotifications` API and is unchanged.

## Verification

- `xcodebuild -workspace Shroud.xcworkspace -scheme Shroud -configuration Debug -sdk iphonesimulator build` → `** BUILD SUCCEEDED **`
- No remaining references to either removed module anywhere in `ios/` (grep across `.swift`/`.h`/`.m`/`.mm`/`.pbxproj`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)