### PR TITLE
FIX: restore isScanActive()

### DIFF
--- a/class/wallets/hd-bip352-wallet.ts
+++ b/class/wallets/hd-bip352-wallet.ts
@@ -17,6 +17,7 @@ import {
   type ScanStateInfo,
   type ScanStatus,
   IDLE_SCAN_STATE,
+  type IScannableWallet,
 } from '../../helpers/silent-payments';
 import { BIP352_ACTIVATION_HEIGHT } from '../../modules/constants';
 import { CreateTransactionResult, CreateTransactionTarget, CreateTransactionUtxo, Transaction, Utxo } from './types.ts';
@@ -30,7 +31,7 @@ const SCAN_PROGRESS_THROTTLE_MS = 500;
 // Number of recent progress samples kept for the windowed ETA throughput estimate.
 const SCAN_ETA_ROLLING_WINDOW = 10;
 
-export class HDSilentPaymentsWallet extends HDTaprootWallet {
+export class HDSilentPaymentsWallet extends HDTaprootWallet implements IScannableWallet {
   static readonly type = 'HDSilentPaymentsWallet';
   static readonly typeReadable = 'HD Silent Payments';
   // @ts-ignore: override
@@ -349,6 +350,10 @@ export class HDSilentPaymentsWallet extends HDTaprootWallet {
     // flag below; it must not tear down the shared indexer.
     this.stopPolling();
     this._emitScanState('idle', IDLE_SCAN_STATE);
+  }
+
+  isScanActive(): boolean {
+    return this.activeScanPromise !== null;
   }
 
   private startPolling(): void {


### PR DESCRIPTION
## Bug :  `ScanProgressBar` never rendered for any wallet

## Description
- [`bfac4ef33`](https://github.com/CypherCommons/shroud/pull/111/changes/bfac4ef33b5fa715e37731472a4204970d2e3411) deleted `isScanActive()` from `HDSilentPaymentsWallet`
- With the method gone, the guard always returned `false`, `useScannableWallet()` always returned `null`, and `ScanProgressBar` never rendered for any wallet

## Changes
- Restores `isScanActive(): boolean { return this.activeScanPromise !== null; }` to `HDSilentPaymentsWallet`
- Imports `IScannableWallet` and adds `implements IScannableWallet` to the class declaration to catch this class of regression at compile time

## Test plan

- [ ] Load an existing wallet (created before the current tip) — scan progress bar should appear and track scan state
- [ ] `npm run lint && npm run tslint` passes with no new errors