### PR TITLE
FIX: Import Wallet dark mode, font, and layout fixes

### DIFF
--- a/ShroudComponents.js
+++ b/ShroudComponents.js
@@ -3,6 +3,7 @@ import React, { forwardRef } from 'react';
 import { Platform, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Text } from '@rneui/themed';
 import { useTheme } from './components/themes';
+import { ClashFont } from './constants/fonts';
 
 /**
  * TODO: remove this comment once this file gets properly converted to typescript.
@@ -52,7 +53,7 @@ export const ShroudFormLabel = props => {
       {...props}
       style={{
         color: colors.foregroundColor,
-        fontWeight: '400',
+        fontFamily: ClashFont.regular,
         marginHorizontal: 20,
       }}
     />
@@ -82,6 +83,7 @@ export const ShroudFormMultiInput = props => {
         backgroundColor: colors.inputBackgroundColor,
         color: colors.foregroundColor,
         textAlignVertical: 'top',
+        fontFamily: ClashFont.regular,
       }}
       autoCorrect={false}
       autoCapitalize="none"

--- a/components/AddressInputScanButton.tsx
+++ b/components/AddressInputScanButton.tsx
@@ -10,6 +10,7 @@ import { detectQRCodeInImage } from 'react-native-camera-kit-no-google';
 import { CommonToolTipActions } from '../typings/CommonToolTipActions';
 import { useSettings } from '../hooks/context/useSettings';
 import { scanQrHelper } from '../helpers/scan-qr';
+import { ClashFont } from '../constants/fonts';
 
 interface AddressInputScanButtonProps {
   isLoading?: boolean;
@@ -167,9 +168,11 @@ const styles = StyleSheet.create({
   },
   scanText: {
     marginLeft: 4,
+    fontFamily: ClashFont.regular,
   },
   linkText: {
     textAlign: 'center',
     fontSize: 16,
+    fontFamily: ClashFont.regular,
   },
 });

--- a/components/WalletBirthSection.tsx
+++ b/components/WalletBirthSection.tsx
@@ -3,6 +3,7 @@ import { Platform, StyleSheet, TextInput, View } from 'react-native';
 import { ShroudFormLabel } from '../ShroudComponents';
 import { useTheme } from './themes';
 import loc from '../loc';
+import { ClashFont } from '../constants/fonts';
 
 interface WalletBirthSectionProps {
   birthDate: string;
@@ -21,7 +22,7 @@ export const WalletBirthSection: React.FC<WalletBirthSectionProps> = ({ birthDat
   });
 
   return (
-    <View style={styles.container}>
+    <View>
       <ShroudFormLabel>{loc.wallet_birth.birth_date_label}</ShroudFormLabel>
       <TextInput
         style={[styles.input, stylesHook.input]}
@@ -40,16 +41,14 @@ export const WalletBirthSection: React.FC<WalletBirthSectionProps> = ({ birthDat
 };
 
 const styles = StyleSheet.create({
-  container: {
-    marginHorizontal: 16,
-  },
   input: {
     borderWidth: 1,
     borderRadius: 4,
     paddingHorizontal: 12,
     paddingVertical: Platform.select({ ios: 14, default: 10 }),
-    marginHorizontal: 0,
+    marginHorizontal: 20,
     marginTop: 6,
     minHeight: 44,
+    fontFamily: ClashFont.regular,
   },
 });

--- a/components/themes.ts
+++ b/components/themes.ts
@@ -183,7 +183,7 @@ export const ShroudDarkTheme: Theme = {
     cta2: '#ffffff',
     outputValue: '#ffffff',
     elevated: '#121212',
-    mainColor: '#0A84FF',
+    mainColor: '#754CE8',
     success: '#202020',
     successCheck: '#00A63E',
     buttonBlueBackgroundColor: '#202020',
@@ -224,6 +224,7 @@ export const ShroudDarkTheme: Theme = {
     incomingIconBorder: '#473F71',
     outgoingIconBackground: '#161616',
     outgoingIconBorder: '#473F71',
+    primary: '#754CE8',
   },
 };
 

--- a/screen/settings/DeleteWallet.tsx
+++ b/screen/settings/DeleteWallet.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import { Alert } from 'react-native';
 import ListItem from '../../components/ListItem';
 import { useStorage } from '../../hooks/context/useStorage';
 import triggerHapticFeedback, { HapticFeedbackTypes } from '../../modules/hapticFeedback';
@@ -8,6 +7,7 @@ import { useExtendedNavigation } from '../../hooks/useExtendedNavigation';
 import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamList';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { CommonActions } from '@react-navigation/native';
+import presentAlert from '../../components/Alert';
 
 type NavigationProps = NativeStackNavigationProp<DetailViewStackParamList, 'DeleteWallet'>;
 
@@ -18,14 +18,14 @@ const DeleteWallet: React.FC = () => {
   const handleDeleteWallet = useCallback(async () => {
     const wallet = wallets.length > 0 ? wallets[0] : null;
     if (!wallet) {
-      Alert.alert(loc.wallets.list_empty_txs1, 'No wallet available to delete');
+      presentAlert({ title: loc.wallets.list_empty_txs1, message: 'No wallet available to delete' });
       return;
     }
 
-    Alert.alert(
-      loc.wallets.details_delete_wallet,
-      loc.wallets.details_are_you_sure,
-      [
+    presentAlert({
+      title: loc.wallets.details_delete_wallet,
+      message: loc.wallets.details_are_you_sure,
+      buttons: [
         {
           text: loc._.cancel,
           style: 'cancel',
@@ -47,8 +47,8 @@ const DeleteWallet: React.FC = () => {
           },
         },
       ],
-      { cancelable: false },
-    );
+      options: { cancelable: false },
+    });
   }, [wallets, handleWalletDeletion, dispatch]);
 
   if (wallets.length === 0) {

--- a/screen/wallets/ImportWallet.tsx
+++ b/screen/wallets/ImportWallet.tsx
@@ -274,7 +274,6 @@ const ImportWallet = () => {
       <TouchableWithoutFeedback accessibilityRole="button" onPress={speedBackdoorTap} testID="SpeedBackdoor">
         <ShroudFormLabel>{loc.wallets.import_explanation}</ShroudFormLabel>
       </TouchableWithoutFeedback>
-      <Spacing20 />
       <View style={styles.mnemonicInputContainer}>
         <ShroudFormMultiInput
           value={importText}

--- a/screen/wallets/ImportWallet.tsx
+++ b/screen/wallets/ImportWallet.tsx
@@ -313,6 +313,7 @@ const ImportWallet = () => {
 const styles = StyleSheet.create({
   root: {
     paddingTop: 10,
+    flexGrow: 1,
   },
   center: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Fix half-black background on Import Wallet screen in dark mode
- Migrate DeleteWallet alert to the presentAlert wrapper
- Apply Clash Grotesk font to shared form, button, and scan components for Text on Import screen to have matching font
- Fix birth date label alignment and normalize label-to-input spacing on Import Wallet
- Fix dark theme mainColor to match brand purple instead of blue

## Test plan
- [x] npm run lint
- [x] npm run tslint
- [x] npm run unit
- [x] Manually verified on device (light/dark mode) on Import Wallet and Delete Wallet flows

## Screenshots of before and after
<img width="250" height="600" alt="image" src="https://github.com/user-attachments/assets/d40096db-f2b5-4cac-9ec2-618ea70a433e" /> <img width="250" height="600" alt="image" src="https://github.com/user-attachments/assets/0e9adc62-6d6b-4643-b5c3-d10fd9501c1d" />

<img width="250" height="600" alt="image" src="https://github.com/user-attachments/assets/14f7b3c9-3891-4767-a4db-d9b2e8a92f83" />  <img width="250" height="600" alt="image" src="https://github.com/user-attachments/assets/1ce6ab1d-b0e1-4fe0-8e90-762df2af466d" />


